### PR TITLE
worked on PayPage.js -> sent the request through a locally hosted proxy server

### DIFF
--- a/src/pages/PayPage.js
+++ b/src/pages/PayPage.js
@@ -32,31 +32,32 @@ function PayPage() {
     ) {
       return alert("valid number should start with 07 or 01");
     }
-    //send request
-    alert(
-      "STILL WORKING ON IT BE PATIENT 😋😋 \n Check tommorrow I should be through 🤩🤩"
-    );
+    // //send request
+    // alert(
+    //   "STILL WORKING ON IT BE PATIENT 😋😋 \n Check tommorrow I should be through 🤩🤩"
+    // );
 
-    // try {
-    //   const key = "s0L1YFYzr4eGANAiVtmhPum9Us9pQnaT";
-    //   const secret = "goca51EHNnZnQHOA";
-    //   const auth = new Buffer.from(`${key}:${secret}`).toString("base64");
+    try {
+      const key = "s0L1YFYzr4eGANAiVtmhPum9Us9pQnaT";
+      const secret = "goca51EHNnZnQHOA";
+      const auth = new Buffer.from(`${key}:${secret}`).toString("base64");
 
-    //   const tokenData = await axios.get(
-    //     "https://sandbox.safaricom.co.ke/oauth/v1/generate?grant_type=client_credentials",
-    //     {
-    //       headers: {
-    //         "Content-Type": "application/json",
-    //         authorization: `Basic ${auth}`,
-    //       },
-    //     }
-    //   );
+      const tokenData = await axios.get(
+        "http://localhost:8080/https://sandbox.safaricom.co.ke/oauth/v1/generate?grant_type=client_credentials", //sends the request through a proxy server
+        {
+          headers: {
+            "Content-Type": "application/json",
+            authorization: `Basic ${auth}`,
+          },
+        }
+      );
 
-    //   console.log(tokenData);
-    // } catch (error) {
-    //   console.log(error);
-    //   alert(error.message);
-    // }
+      console.log(tokenData);
+      console.log(tokenData.data.access_token); //get the access_token from daraja API
+    } catch (error) {
+      console.log(error);
+      alert(error.message);
+    }
   };
 
   return (


### PR DESCRIPTION
Our aim is to make a request to daraja API, to get an access_token. But for as to make the request, the response from the daraja API, which is an external API must have CORS headers such that Access-Control-Allow-Origin: * otherwise there will be a CORS error and the response will not be received by the client/browser. Consequently, we have to configure, this responses to have CORS headers but then we don't want to use a server to call the request, maybe consuming the daraja API in the backend, we could have just used cors as the middleware and all will work fine. But since we want, to call the the daraja API directly from the client-side using a frontend framework such as REACT JS, will therefore must find a way to add the CORS headers to the response before they reach the client... There is no exception to this, and therefore we thought of a proxy server which would only be used to add the CORS headers to the responses. In other words, the client will send the request to the proxy server and it would then make the request to daraja API on behalf of the client, receive responses with no CORS headers and pass them to the client having CORS headers. Please check on this repo for the proxy server https://github.com/wamae-ndiritu/proxy-server.git